### PR TITLE
feat: polish all UI to match exact Obsidian design tokens (#4)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -14,7 +14,7 @@
 @theme inline {
   --font-heading: var(--font-sans);
 
-  --font-sans: var(--font-geist-sans);
+  --font-sans: var(--font-inter);
 
   --color-sidebar-ring: var(--sidebar-ring);
 
@@ -78,19 +78,20 @@
 
   --color-background: var(--background);
 
-  --radius-sm: calc(var(--radius) * 0.6);
+  /* Obsidian radius scale: 4px / 8px / 12px / 16px */
+  --radius-sm: 4px;   /* Obsidian --radius-s */
 
-  --radius-md: calc(var(--radius) * 0.8);
+  --radius-md: 8px;   /* Obsidian --radius-m */
 
-  --radius-lg: var(--radius);
+  --radius-lg: 8px;   /* Obsidian --radius-m (default) */
 
-  --radius-xl: calc(var(--radius) * 1.4);
+  --radius-xl: 12px;  /* Obsidian --radius-l */
 
-  --radius-2xl: calc(var(--radius) * 1.8);
+  --radius-2xl: 16px; /* Obsidian --radius-xl */
 
-  --radius-3xl: calc(var(--radius) * 2.2);
+  --radius-3xl: 16px; /* Obsidian --radius-xl */
 
-  --radius-4xl: calc(var(--radius) * 2.6);
+  --radius-4xl: 16px; /* Obsidian --radius-xl */
 }
 
 @layer base {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from 'next'
-import { Geist, Geist_Mono } from 'next/font/google'
+import { Inter } from 'next/font/google'
 import { TooltipProvider } from '@/components/ui/tooltip'
 import { getContentTree } from '@/lib/content/getContentTree'
 import AppShell from '@/components/layout/AppShell'
@@ -8,14 +8,10 @@ import { Analytics } from '@vercel/analytics/next'
 import { SpeedInsights } from '@vercel/speed-insights/next'
 import './globals.css'
 
-const geistSans = Geist({
-  variable: '--font-geist-sans',
+const inter = Inter({
+  variable: '--font-inter',
   subsets: ['latin'],
-})
-
-const geistMono = Geist_Mono({
-  variable: '--font-geist-mono',
-  subsets: ['latin'],
+  weight: ['400', '500', '600', '700'],
 })
 
 export const metadata: Metadata = {
@@ -58,7 +54,7 @@ export default async function RootLayout({
       lang="en"
       data-theme="dark"
       suppressHydrationWarning
-      className={`${geistSans.variable} ${geistMono.variable} h-full antialiased`}
+      className={`${inter.variable} h-full antialiased`}
     >
       <head>
         <script

--- a/src/styles/prose.css
+++ b/src/styles/prose.css
@@ -1,22 +1,28 @@
-/* .prose — Markdown content styling */
+/* .prose — Markdown content styling
+   All values sourced from Obsidian design tokens.
+   Reference: docs/spike/spike-obsidian-ui-tokens.md */
 
 .prose {
   color: var(--foreground);
-  line-height: 1.7;
-  font-size: 0.9375rem; /* 15px */
+  line-height: 1.5; /* Obsidian --line-height-normal */
+  font-size: 1rem; /* 16px — Obsidian --font-text-size */
 }
 
+/* Headings — Obsidian em-based scale */
+
 .prose h1 {
-  font-size: 1.5rem;
-  font-weight: 700;
+  font-size: 2em; /* Obsidian --h1-size */
+  font-weight: 700; /* Obsidian --h1-weight */
+  line-height: 1.2; /* Obsidian --h1-line-height */
   margin-top: 0;
   margin-bottom: 1rem;
   color: var(--foreground);
 }
 
 .prose h2 {
-  font-size: 1.25rem;
-  font-weight: 600;
+  font-size: 1.6em; /* Obsidian --h2-size */
+  font-weight: 600; /* Obsidian --h2-weight */
+  line-height: 1.2; /* Obsidian --h2-line-height */
   margin-top: 2rem;
   margin-bottom: 0.75rem;
   color: var(--foreground);
@@ -25,17 +31,49 @@
 }
 
 .prose h3 {
-  font-size: 1.0625rem;
-  font-weight: 600;
+  font-size: 1.37em; /* Obsidian --h3-size */
+  font-weight: 600; /* Obsidian --h3-weight */
+  line-height: 1.3; /* Obsidian --h3-line-height */
   margin-top: 1.5rem;
   margin-bottom: 0.5rem;
   color: var(--foreground);
 }
 
+.prose h4 {
+  font-size: 1.25em; /* Obsidian --h4-size */
+  font-weight: 600; /* Obsidian --h4-weight */
+  line-height: 1.4; /* Obsidian --h4-line-height */
+  margin-top: 1.25rem;
+  margin-bottom: 0.375rem;
+  color: var(--foreground);
+}
+
+.prose h5 {
+  font-size: 1.12em; /* Obsidian --h5-size */
+  font-weight: 600; /* Obsidian --h5-weight */
+  line-height: 1.5; /* Obsidian --h5-line-height */
+  margin-top: 1rem;
+  margin-bottom: 0.25rem;
+  color: var(--foreground);
+}
+
+.prose h6 {
+  font-size: 1.12em; /* Obsidian --h6-size */
+  font-weight: 600; /* Obsidian --h6-weight */
+  line-height: 1.5; /* Obsidian --h6-line-height */
+  margin-top: 1rem;
+  margin-bottom: 0.25rem;
+  color: var(--foreground);
+}
+
+/* Paragraph — Obsidian --p-spacing */
+
 .prose p {
   margin-top: 0;
-  margin-bottom: 1rem;
+  margin-bottom: 1rem; /* --p-spacing */
 }
+
+/* Links */
 
 .prose a {
   color: var(--accent);
@@ -57,6 +95,8 @@
   opacity: 0.6;
 }
 
+/* Lists */
+
 .prose ul,
 .prose ol {
   padding-left: 1.5rem;
@@ -67,74 +107,92 @@
   margin-bottom: 0.25rem;
 }
 
+/* Blockquotes — Obsidian defaults: 2px border, transparent bg, normal style */
+
 .prose blockquote {
-  border-left: 3px solid var(--accent);
+  border-left: 2px solid var(--accent); /* Obsidian --blockquote-border-thickness */
+  background: transparent; /* Obsidian --blockquote-background-color */
   padding-left: 1rem;
   margin: 1.5rem 0;
-  color: var(--muted-foreground);
-  font-style: italic;
+  color: inherit; /* Obsidian --blockquote-color */
+  font-style: normal; /* Obsidian --blockquote-font-style */
 }
 
+/* Inline code — Obsidian monospace stack, 0.875em */
+
 .prose code {
-  font-family: var(--font-geist-mono, ui-monospace, monospace);
-  font-size: 0.875em;
+  font-family: var(--font-mono);
+  font-size: 0.875em; /* Obsidian --code-size */
   background: var(--muted);
-  border-radius: 3px;
+  border-radius: 4px; /* Obsidian --radius-s */
   padding: 0.15em 0.35em;
   color: var(--foreground);
 }
 
+/* Code blocks — Obsidian code variables */
+
 .prose pre {
-  background: var(--muted);
-  border-radius: 6px;
+  background: var(--code-block-bg); /* Obsidian --code-background */
+  border-radius: 8px; /* Obsidian --radius-m */
   padding: 1rem;
   overflow-x: auto;
+  white-space: pre-wrap; /* Obsidian --code-white-space */
   margin-bottom: 1rem;
 }
 
 .prose pre code {
   background: none;
   padding: 0;
-  font-size: 0.875rem;
+  font-size: 0.875em; /* Obsidian --code-size */
 }
+
+/* Tables — Obsidian: transparent bg, normal weight headers, muted header color */
 
 .prose table {
   width: 100%;
   border-collapse: collapse;
   margin-bottom: 1rem;
-  font-size: 0.9rem;
+  background: transparent; /* Obsidian --table-background */
 }
 
 .prose th {
   text-align: left;
   padding: 0.5rem 0.75rem;
-  background: var(--muted);
-  border: 1px solid var(--border);
-  font-weight: 600;
-  color: var(--foreground);
+  background: transparent; /* Obsidian --table-header-background */
+  border: 1px solid var(--border); /* Obsidian --table-border-width */
+  font-weight: 400; /* Obsidian --table-header-weight (normal) */
+  color: var(--muted-foreground); /* Obsidian --table-header-color */
 }
 
 .prose td {
   padding: 0.5rem 0.75rem;
   border: 1px solid var(--border);
   color: var(--foreground);
+  vertical-align: top; /* Obsidian --table-cell-vertical-alignment */
 }
 
-.prose tr:nth-child(even) td {
-  background: color-mix(in srgb, var(--muted) 30%, transparent);
+/* Row hover instead of striping — matches Obsidian */
+.prose tr:hover td {
+  background: var(--muted); /* Obsidian --table-row-background-hover */
 }
+
+/* Horizontal rule — Obsidian: 2px, border color */
 
 .prose hr {
   border: none;
-  border-top: 1px solid var(--border);
+  border-top: 2px solid var(--border); /* Obsidian --hr-thickness */
   margin: 2rem 0;
 }
+
+/* Images */
 
 .prose img {
   max-width: 100%;
   height: auto;
-  border-radius: 6px;
+  border-radius: 8px; /* Obsidian --radius-m */
 }
+
+/* Strong — Obsidian --bold-weight is 600 (semibold) */
 
 .prose strong {
   font-weight: 600;
@@ -143,4 +201,23 @@
 
 .prose em {
   font-style: italic;
+}
+
+/* Scrollbar — Obsidian opacity-based approach */
+
+.prose::-webkit-scrollbar {
+  width: 8px;
+}
+
+.prose::-webkit-scrollbar-track {
+  background: var(--scrollbar-bg, transparent);
+}
+
+.prose::-webkit-scrollbar-thumb {
+  background: var(--scrollbar-thumb-bg, rgba(128, 128, 128, 0.2));
+  border-radius: 4px;
+}
+
+.prose::-webkit-scrollbar-thumb:active {
+  background: var(--scrollbar-active-thumb-bg, rgba(128, 128, 128, 0.4));
 }

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -1,70 +1,90 @@
 /* ─────────────────────────────────────────
    BASE TOKENS (shared structure, non-color)
+   Source: Obsidian CSS Variables Reference
+   https://docs.obsidian.md/Reference/CSS+variables
    ───────────────────────────────────────── */
 
 :root {
-  --font-sans: var(--font-geist-sans);
-  --font-mono:
-    'JetBrains Mono', 'Fira Code', 'Cascadia Code', ui-monospace, monospace;
+  --font-sans: var(--font-inter), 'Inter', -apple-system, BlinkMacSystemFont,
+    'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+  --font-mono: Menlo, SFMono-Regular, Consolas, 'Source Code Pro', monospace;
+
+  /* Shadows — Obsidian --shadow-s and --shadow-l */
+  --shadow-s: rgba(0, 0, 0, 0.08) 0px 12px 24px -4px,
+    rgba(0, 0, 0, 0.04) 0px 8px 16px -4px;
+  --shadow-l: 0 14px 62px 0 rgba(0, 0, 0, 0.25);
 }
 
 /* ─────────────────────────────────────────
    LIGHT THEME
+   Source: Obsidian base color scale (light)
    ───────────────────────────────────────── */
 
 [data-theme='light'] {
-  /* Core surfaces */
-  --background: #ffffff;
-  --foreground: #1a1a1a;
-  --sidebar-bg: #f7f7f7;
-  --border: #e0e0e0;
+  /* Core surfaces — Obsidian base scale */
+  --background: #ffffff; /* --color-base-00 */
+  --foreground: #222222; /* --color-base-100 (--text-normal) */
+  --sidebar-bg: #fafafa; /* --color-base-10 (--background-primary-alt) */
+  --border: #e0e0e0; /* --color-base-30 (--background-modifier-border) */
 
-  /* Accent */
-  --accent: #7b61ff;
-  --accent-foreground: #ffffff;
+  /* Accent — Obsidian hsl(254, 80%, 68%) light */
+  --accent: #705dcf; /* --text-accent */
+  --accent-foreground: #ffffff; /* --text-on-accent */
 
   /* Muted */
-  --muted: #f0f0f0;
-  --muted-foreground: #777777;
+  --muted: #f6f6f6; /* --color-base-20 (--background-secondary) */
+  --muted-foreground: #5a5a5a; /* --color-base-70 (--text-muted) */
 
   /* Text aliases */
-  --text-primary: #1a1a1a;
-  --text-secondary: #555555;
-  --text-muted: #777777;
+  --text-primary: #222222; /* --text-normal */
+  --text-secondary: #5a5a5a; /* --text-muted */
+  --text-muted: #5a5a5a; /* --text-muted */
+  --text-faint: #ababab; /* --color-base-50 (--text-faint) */
 
   /* Nav */
-  --nav-active-bg: #eae8ff;
-  --nav-active-fg: #5a48d0;
+  --nav-active-bg: #f2f3f5; /* --interactive-normal */
+  --nav-active-fg: #705dcf; /* --text-accent */
 
   /* Popovers / Dropdowns */
-  --popover-bg: #ffffff;
-  --popover-border: #e0e0e0;
+  --popover-bg: #ffffff; /* --color-base-00 */
+  --popover-border: #e0e0e0; /* --color-base-30 */
 
-  /* Code */
-  --code-bg: #f0f0f0;
-  --code-block-bg: #f5f5f5;
-  --code-fg: #c7254e;
+  /* Code — Obsidian code variables */
+  --code-bg: #f6f6f6; /* --background-secondary */
+  --code-block-bg: #fafafa; /* --background-primary-alt (--code-background) */
+  --code-fg: #222222; /* --text-normal */
 
-  /* Links */
-  --link-fg: #7b61ff;
-  --wikilink-fg: #4a4a8a;
-  --wikilink-underline: #a0a0c0;
-  --wikilink-hover-fg: #7b61ff;
-  --wikilink-missing-fg: #c0504a;
+  /* Links — Obsidian uses purple accent for all links */
+  --link-fg: #705dcf; /* --text-accent */
+  --wikilink-fg: #705dcf;
+  --wikilink-underline: rgba(112, 93, 207, 0.3);
+  --wikilink-hover-fg: #7a6ae6; /* --text-accent-hover */
+  --wikilink-missing-fg: #e93147; /* --color-red */
 
   /* Verified badge */
   --verified-badge-bg: #eff7f2;
   --verified-badge-border: #b8dec8;
   --verified-badge-fg: #2d6a4f;
 
-  /* Search */
-  --search-highlight-bg: #fff380;
-  --search-highlight-fg: #1a1a1a;
+  /* Search — Obsidian --text-highlight-bg */
+  --search-highlight-bg: rgba(255, 208, 0, 0.4);
+  --search-highlight-fg: #222222;
 
   /* Graph */
-  --graph-bg: #fafafa;
-  --graph-edge-color: #bbbbbb;
+  --graph-bg: #fafafa; /* --background-primary-alt */
+  --graph-edge-color: #bdbdbd; /* --color-base-40 */
   --graph-node-stroke: rgba(0, 0, 0, 0.15);
+
+  /* Scrollbar — Obsidian opacity-based */
+  --scrollbar-bg: rgba(0, 0, 0, 0.05);
+  --scrollbar-thumb-bg: rgba(0, 0, 0, 0.1);
+  --scrollbar-active-thumb-bg: rgba(0, 0, 0, 0.2);
+
+  /* Interactive elements */
+  --interactive-normal: #f2f3f5;
+  --interactive-hover: #e9e9e9;
+  --interactive-accent: #7b6cd9;
+  --interactive-accent-hover: #8273e6;
 
   /* File type colors */
   --file-type-promo: #2a9d4e;
@@ -72,68 +92,81 @@
 
 /* ─────────────────────────────────────────
    DARK THEME (default)
+   Source: Obsidian base color scale (dark)
    ───────────────────────────────────────── */
 
 [data-theme='dark'] {
-  /* Core surfaces */
-  --background: #1e1e2e;
-  --foreground: #cdd6f4;
-  --sidebar-bg: #181825;
-  --border: #313244;
+  /* Core surfaces — Obsidian base scale */
+  --background: #1e1e1e; /* --color-base-00 */
+  --foreground: #dadada; /* --color-base-100 (--text-normal) */
+  --sidebar-bg: #242424; /* --color-base-10 (--background-primary-alt) */
+  --border: #363636; /* --color-base-30 (--background-modifier-border) */
 
-  /* Accent */
-  --accent: #cba6f7;
-  --accent-foreground: #1e1e2e;
+  /* Accent — Obsidian hsl(254, 80%, 68%) dark */
+  --accent: #7f6df2; /* --text-accent */
+  --accent-foreground: #1e1e1e; /* --color-base-00 */
 
   /* Muted */
-  --muted: #2a2a3e;
-  --muted-foreground: #6c7086;
+  --muted: #262626; /* --color-base-20 (--background-secondary) */
+  --muted-foreground: #bababa; /* --color-base-70 (--text-muted) */
 
   /* Text aliases */
-  --text-primary: #cdd6f4;
-  --text-secondary: #a6adc8;
-  --text-muted: #6c7086;
+  --text-primary: #dadada; /* --text-normal */
+  --text-secondary: #bababa; /* --text-muted */
+  --text-muted: #bababa; /* --text-muted */
+  --text-faint: #666666; /* --color-base-50 (--text-faint) */
 
   /* Nav */
-  --nav-active-bg: #313244;
-  --nav-active-fg: #cba6f7;
+  --nav-active-bg: #2a2a2a; /* --interactive-normal */
+  --nav-active-fg: #7f6df2; /* --text-accent */
 
   /* Popovers / Dropdowns */
-  --popover-bg: #24273a;
-  --popover-border: #363a52;
+  --popover-bg: #242424; /* --color-base-05 */
+  --popover-border: #363636; /* --color-base-30 */
 
-  /* Code */
-  --code-bg: #2a2a3e;
-  --code-block-bg: #232336;
-  --code-fg: #f38ba8;
+  /* Code — Obsidian code variables */
+  --code-bg: #262626; /* --background-secondary */
+  --code-block-bg: #242424; /* --background-primary-alt (--code-background) */
+  --code-fg: #dadada; /* --text-normal */
 
   /* Links */
-  --link-fg: #89b4fa;
-  --wikilink-fg: #b4befe;
-  --wikilink-underline: #585b70;
-  --wikilink-hover-fg: #cba6f7;
-  --wikilink-missing-fg: #f38ba8;
+  --link-fg: #7f6df2; /* --text-accent */
+  --wikilink-fg: #7f6df2;
+  --wikilink-underline: rgba(127, 109, 242, 0.3);
+  --wikilink-hover-fg: #8875ff; /* --text-accent-hover */
+  --wikilink-missing-fg: #fb464c; /* --color-red */
 
   /* Verified badge */
   --verified-badge-bg: #1e2d24;
   --verified-badge-border: #2d4a38;
-  --verified-badge-fg: #a6e3a1;
+  --verified-badge-fg: #44cf6e; /* --color-green (dark) */
 
-  /* Search */
-  --search-highlight-bg: #f9e2af;
-  --search-highlight-fg: #1e1e2e;
+  /* Search — Obsidian --text-highlight-bg */
+  --search-highlight-bg: rgba(255, 208, 0, 0.4);
+  --search-highlight-fg: #dadada;
 
   /* Graph */
-  --graph-bg: #181825;
-  --graph-edge-color: #45475a;
+  --graph-bg: #242424; /* --background-primary-alt */
+  --graph-edge-color: #555555; /* --color-base-40 */
   --graph-node-stroke: rgba(255, 255, 255, 0.1);
+
+  /* Scrollbar — Obsidian opacity-based */
+  --scrollbar-bg: rgba(255, 255, 255, 0.05);
+  --scrollbar-thumb-bg: rgba(255, 255, 255, 0.1);
+  --scrollbar-active-thumb-bg: rgba(255, 255, 255, 0.2);
+
+  /* Interactive elements */
+  --interactive-normal: #2a2a2a;
+  --interactive-hover: #303030;
+  --interactive-accent: #483699;
+  --interactive-accent-hover: #4d3ca6;
 
   /* File type colors */
   --file-type-promo: #3fb950;
 }
 
 /* ─────────────────────────────────────────
-   BLUE THEME
+   BLUE THEME (GitHub-inspired, non-Obsidian)
    ───────────────────────────────────────── */
 
 [data-theme='blue'] {
@@ -155,6 +188,7 @@
   --text-primary: #e6edf3;
   --text-secondary: #c9d1d9;
   --text-muted: #8b949e;
+  --text-faint: #484f58;
 
   /* Nav */
   --nav-active-bg: #1f3a5f;
@@ -189,6 +223,17 @@
   --graph-bg: #090d12;
   --graph-edge-color: #21262d;
   --graph-node-stroke: rgba(255, 255, 255, 0.08);
+
+  /* Scrollbar */
+  --scrollbar-bg: rgba(255, 255, 255, 0.04);
+  --scrollbar-thumb-bg: rgba(255, 255, 255, 0.08);
+  --scrollbar-active-thumb-bg: rgba(255, 255, 255, 0.16);
+
+  /* Interactive elements */
+  --interactive-normal: #161b22;
+  --interactive-hover: #1c2028;
+  --interactive-accent: #1f6feb;
+  --interactive-accent-hover: #388bfd;
 
   /* File type colors */
   --file-type-promo: #4ade80;


### PR DESCRIPTION
## Summary

Closes #4

- Switched font from Geist to Inter (weights 400/500/600/700) and monospace from JetBrains Mono to Menlo/SFMono-Regular/Consolas/Source Code Pro — matching Obsidian's `--default-font` and `--font-monospace-default`
- Updated all three themes (dark/light/blue) with exact Obsidian hex values: dark grays `#1e1e1e`/`#242424`/`#262626`/`#363636`, light whites `#ffffff`/`#fafafa`/`#f6f6f6`/`#e0e0e0`, accent purple `hsl(254, 80%, 68%)`
- Rewrote prose.css with Obsidian-sourced values: em-based heading scale, 16px body text, 2px blockquote borders (not italic), transparent table headers with normal weight, 0.875em code size, 2px HR thickness

## Changes

- `src/app/layout.tsx` — Geist → Inter font with 4 weights, single CSS variable `--font-inter`
- `src/styles/themes.css` — All 3 theme blocks updated to exact Obsidian color tokens; added scrollbar, shadow, and interactive element variables
- `src/styles/prose.css` — Complete rewrite: h1–h6 with Obsidian em scale, blockquotes (2px/transparent/normal), tables (transparent bg, 400 weight headers, row hover), code (0.875em, pre-wrap), HR (2px), scrollbar styling
- `src/app/globals.css` — Font reference `--font-geist-sans` → `--font-inter`; radius scale changed to Obsidian values (4/8/12/16px)

## How to verify

1. `npx next build` — should pass (verified)
2. Run dev server and check dark theme: bg should be `#1e1e1e`, text `#dadada`, borders `#363636`
3. Verify font is Inter (check DevTools computed styles)
4. Check headings are em-based (H1 should be 32px at 16px body)
5. Verify blockquotes have 2px purple left border and are NOT italic
6. Verify table headers have normal weight (400) and muted color
7. Check code blocks use Menlo/system monospace, not JetBrains Mono
8. Verify accent color is purple (~`#7f6df2` dark / `#705dcf` light)

## Testing

- [x] Build passes (`npx next build` — all 46 pages generated)
- [x] No Geist font references remain in source
- [x] Manual verification of CSS variable values against spike document
- [ ] Visual regression check across all pages

## Notes

- Blue theme is GitHub-inspired (non-Obsidian) so it retains its own palette but now includes scrollbar and interactive tokens
- `prose-sm prose-invert` on the legal page are Tailwind Typography classes (no-ops since we don't use that plugin) — our custom `.prose` class still applies correctly
- The `--font-mono` variable in themes.css now uses system monospace fonts, eliminating the need to load a web font for code

---
Generated with [Claude Code](https://claude.com/claude-code)