### PR TITLE
feat: add vertical pane title strip component (#16)

### DIFF
--- a/src/components/content/PaneTitleStrip.tsx
+++ b/src/components/content/PaneTitleStrip.tsx
@@ -1,0 +1,38 @@
+'use client'
+
+import { cn } from '@/lib/utils'
+
+type PaneTitleStripProps = {
+  title: string
+  isActive: boolean
+  onClick: () => void
+}
+
+export default function PaneTitleStrip({
+  title,
+  isActive,
+  onClick,
+}: PaneTitleStripProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-label={`Activate pane: ${title}`}
+      className={cn(
+        'flex h-full w-6 shrink-0 items-start justify-center',
+        'cursor-pointer border-r border-[var(--border)]',
+        'transition-colors duration-150',
+        isActive
+          ? 'bg-[var(--background)] text-[var(--accent)]'
+          : 'bg-[var(--sidebar-bg)] text-[var(--muted-foreground)] hover:bg-[var(--muted)] hover:text-[var(--foreground)]',
+      )}
+    >
+      <span
+        className="truncate pt-2 text-[11px] font-medium leading-none"
+        style={{ writingMode: 'vertical-rl' }}
+      >
+        {title}
+      </span>
+    </button>
+  )
+}


### PR DESCRIPTION
## Summary

Closes #16

- Created `PaneTitleStrip` component with vertical text rendering via `writing-mode: vertical-rl`
- Fixed 24px width (`w-6`) with top-to-bottom text flow
- Active state uses `--accent` text on `--background`, inactive uses `--muted-foreground` on `--sidebar-bg`
- Click handler for pane activation with accessible button element and aria-label

## Changes

- `src/components/content/PaneTitleStrip.tsx` — new component

## How to verify

1. Import and render the component in a test page
2. Verify text reads top-to-bottom
3. Verify active vs inactive styling differs (accent color vs muted)
4. Verify click handler fires
5. Verify strip width is consistent (24px)

## Testing

- [ ] Component renders without errors
- [ ] Build succeeds
- [ ] Manual verification done

---
Generated with [Claude Code](https://claude.com/claude-code)