### PR TITLE
feat: consolidate nav sidebar bottom to single row (#20)

### DIFF
--- a/src/components/content/ContentFooter.tsx
+++ b/src/components/content/ContentFooter.tsx
@@ -1,0 +1,22 @@
+import Link from 'next/link'
+
+export default function ContentFooter() {
+  return (
+    <footer className="mx-auto max-w-3xl border-t border-[var(--border)] px-6 py-4 text-[11px] text-[var(--muted-foreground)]">
+      <div className="flex items-center gap-3">
+        <Link
+          href="/legal/terms-of-service"
+          className="hover:text-[var(--foreground)]"
+        >
+          Terms
+        </Link>
+        <Link
+          href="/legal/disclaimer"
+          className="hover:text-[var(--foreground)]"
+        >
+          Disclaimer
+        </Link>
+      </div>
+    </footer>
+  )
+}

--- a/src/components/content/ContentPanel.tsx
+++ b/src/components/content/ContentPanel.tsx
@@ -4,6 +4,7 @@ import { BREAKPOINTS } from '@/lib/constants'
 import { useAppShell } from '@/contexts/AppShellContext'
 import TabBar from '@/components/content/TabBar'
 import { BreadcrumbBar } from '@/components/content/BreadcrumbBar'
+import ContentFooter from '@/components/content/ContentFooter'
 
 export default function ContentPanel({ children }: { children: React.ReactNode }) {
   const {
@@ -32,7 +33,10 @@ export default function ContentPanel({ children }: { children: React.ReactNode }
         }
       />
       <BreadcrumbBar activeSlug={activeSlug} />
-      <div className="flex-1 overflow-y-auto">{children}</div>
+      <div className="flex-1 overflow-y-auto">
+        {children}
+        <ContentFooter />
+      </div>
     </div>
   )
 }

--- a/src/components/nav/NavPanel.tsx
+++ b/src/components/nav/NavPanel.tsx
@@ -1,10 +1,14 @@
 'use client'
 
-import { PanelLeft, Search } from 'lucide-react'
-import Link from 'next/link'
+import { PanelLeft, Search, Settings } from 'lucide-react'
 import { useAppShell } from '@/contexts/AppShellContext'
 import NavFileTree from '@/components/nav/NavFileTree'
 import { ThemeToggle } from '@/components/nav/ThemeToggle'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
 import { useSearch } from '@/contexts/SearchContext'
 import { AuthButton } from '@/components/auth/AuthButton'
 
@@ -61,27 +65,18 @@ export default function NavPanel({ collapsed, onToggleCollapse }: NavPanelProps)
         </div>
       )}
 
-      {/* Legal links */}
-      {!collapsed && (
-        <div className="flex shrink-0 items-center gap-3 border-t border-[var(--border)] px-3 py-1.5">
-          <Link
-            href="/legal/terms-of-service"
-            className="text-[11px] text-[var(--muted-foreground)] hover:text-[var(--foreground)]"
-          >
-            Terms
-          </Link>
-          <Link
-            href="/legal/disclaimer"
-            className="text-[11px] text-[var(--muted-foreground)] hover:text-[var(--foreground)]"
-          >
-            Disclaimer
-          </Link>
-        </div>
-      )}
-
-      {/* Bottom bar */}
+      {/* Bottom bar — single compact row matching Obsidian */}
       {!collapsed && (
         <div className="flex h-10 shrink-0 items-center justify-between border-t border-[var(--border)] px-3">
+          <Tooltip>
+            <TooltipTrigger
+              aria-label="Settings"
+              className="flex size-7 items-center justify-center rounded-md hover:bg-[var(--muted)]"
+            >
+              <Settings size={16} />
+            </TooltipTrigger>
+            <TooltipContent>Settings</TooltipContent>
+          </Tooltip>
           <ThemeToggle />
         </div>
       )}


### PR DESCRIPTION
## Summary

Closes #20

- Consolidated nav sidebar bottom from two rows to a single compact 40px row matching the Obsidian ui-guide spec
- Left side: Settings icon (placeholder for future settings modal)
- Right side: Theme toggle (cycles light/dark/blue)
- Legal links relocated to new `ContentFooter` component at the bottom of every page's scroll area

## Changes

- `src/components/nav/NavPanel.tsx` — removed legal links section and standalone theme toggle row; replaced with single bottom bar containing Settings icon + ThemeToggle
- `src/components/content/ContentFooter.tsx` — new component rendering Terms and Disclaimer links
- `src/components/content/ContentPanel.tsx` — added ContentFooter inside scroll area

## How to verify

1. Run `pnpm dev` and open the app
2. Check the nav sidebar bottom renders as a single compact row
3. Verify Settings icon on the left, theme toggle on the right
4. Scroll to the bottom of any content page to verify legal links (Terms, Disclaimer) are present
5. Click theme toggle — should cycle through light/dark/blue themes

## Testing

- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [ ] Manual verification

---
Generated with [Claude Code](https://claude.com/claude-code)