### PR TITLE
feat: add pane data model to AppShellContext (#13)

### DIFF
--- a/src/contexts/AppShellContext.tsx
+++ b/src/contexts/AppShellContext.tsx
@@ -1,9 +1,9 @@
 'use client'
 
-import { createContext, useContext, useState, useCallback } from 'react'
+import { createContext, useContext, useState, useCallback, useMemo } from 'react'
 import { usePathname, useRouter } from 'next/navigation'
 import type { User } from '@supabase/supabase-js'
-import type { TreeNode, TabEntry } from '@/types/content'
+import type { TreeNode, TabEntry, PaneEntry } from '@/types/content'
 import { useLocalStorage } from '@/hooks/useLocalStorage'
 import { useViewport } from '@/hooks/useViewport'
 import { useSupabaseUser } from '@/hooks/useSupabaseUser'
@@ -21,6 +21,13 @@ type AppShellContextValue = {
   // Panel 1 mobile overlay
   panel1OverlayOpen: boolean
   setPanel1OverlayOpen: (open: boolean) => void
+
+  // Panes (Obsidian-style split panes)
+  panes: PaneEntry[]
+  activePaneId: string
+  openPane: (slug: string | null) => void
+  closePane: (id: string) => void
+  setActivePane: (id: string) => void
 
   // Panel 3
   panel3Mode: 'graph' | 'compare'
@@ -59,6 +66,44 @@ export function AppShellProvider({ treeData, children }: AppShellProviderProps) 
   const { user, loading: authLoading } = useSupabaseUser()
   const { openTabs, activeSlug, closeTab } = useTabManager(treeData, pathname)
 
+  // Pane state — data model only, no UI changes
+  const defaultPane: PaneEntry = useMemo(() => ({
+    id: 'pane-default',
+    slug: activeSlug || null,
+    title: 'Home',
+    isCollapsed: false,
+  }), []) // intentionally empty deps — only used as initial value
+
+  const [panes, setPanes] = useLocalStorage<PaneEntry[]>('panes', [defaultPane])
+  const [activePaneId, setActivePaneId] = useLocalStorage<string>('activePaneId', 'pane-default')
+
+  const openPane = useCallback((slug: string | null) => {
+    const id = `pane-${Date.now()}`
+    const title = slug ? slug.split('/').pop() ?? 'Untitled' : 'Empty'
+    const newPane: PaneEntry = { id, slug, title, isCollapsed: false }
+    setPanes((prev) => [...prev, newPane])
+    setActivePaneId(id)
+  }, [setPanes, setActivePaneId])
+
+  const closePane = useCallback((id: string) => {
+    setPanes((prev) => {
+      // Never close the last pane
+      if (prev.length <= 1) return prev
+      return prev.filter((p) => p.id !== id)
+    })
+    // If closing the active pane, activate an adjacent one
+    setActivePaneId((prevId) => {
+      if (prevId !== id) return prevId
+      return panes.length > 1
+        ? (panes.find((p) => p.id !== id)?.id ?? panes[0].id)
+        : prevId
+    })
+  }, [setPanes, setActivePaneId, panes])
+
+  const setActivePane = useCallback((id: string) => {
+    setActivePaneId(id)
+  }, [setActivePaneId])
+
   const [panel3Mode, setPanel3Mode] = useLocalStorage<'graph' | 'compare'>('panel3Mode', 'graph')
   const [panel3Visible, setPanel3Visible] = useState(false)
   const [panel1OverlayOpen, setPanel1OverlayOpen] = useState(false)
@@ -79,6 +124,11 @@ export function AppShellProvider({ treeData, children }: AppShellProviderProps) 
     navigateTo,
     openTabs,
     closeTab,
+    panes,
+    activePaneId,
+    openPane,
+    closePane,
+    setActivePane,
     panel1OverlayOpen,
     setPanel1OverlayOpen,
     panel3Mode,

--- a/src/types/content.ts
+++ b/src/types/content.ts
@@ -29,6 +29,13 @@ export type TabEntry = {
   title: string // display label from frontmatter or slug-derived
 }
 
+export interface PaneEntry {
+  id: string
+  slug: string | null
+  title: string
+  isCollapsed: boolean
+}
+
 export type SourceEntry = {
   url: string
   label: string


### PR DESCRIPTION
## Summary

Closes #13

- Added `PaneEntry` interface to `src/types/content.ts`
- Extended `AppShellContext` with `panes`, `activePaneId`, `openPane`, `closePane`, `setActivePane`
- Existing `openTabs`/`closeTab`/`activeSlug` consumers remain fully functional during migration
- Closing the last pane is a no-op (at least one pane always exists)
- Pane state persisted to localStorage via `useLocalStorage`

## Changes

- `src/types/content.ts` — added PaneEntry interface
- `src/contexts/AppShellContext.tsx` — added pane state and actions

## How to verify

1. Run `pnpm build` — no compile errors
2. Run `pnpm dev` — existing tab behavior works unchanged
3. Verify in React DevTools that panes array exists in context

## Testing

- [x] TypeScript type-check passes
- [x] Build succeeds
- [ ] Manual verification in browser

---
Generated with [Claude Code](https://claude.com/claude-code)