### PR TITLE
fix: remove misleading resize affordance from nav sidebar (#8)

### DIFF
--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -28,7 +28,7 @@ function AppShellLayout({ children }: { children: React.ReactNode }) {
       {viewportWidth >= BREAKPOINTS.MOBILE ? (
         <div
           style={{ width: panel1Collapsed ? LAYOUT.PANEL1_COLLAPSED : LAYOUT.PANEL1_WIDTH, transition: 'width 200ms ease' }}
-          className="shrink-0 overflow-hidden border-r border-[var(--border)] bg-[var(--sidebar-bg)]"
+          className="shrink-0 overflow-hidden border-r border-[var(--border)] bg-[var(--sidebar-bg)] cursor-default"
         >
           <NavPanel collapsed={panel1Collapsed} onToggleCollapse={() => setPanel1Collapsed((v) => !v)} />
         </div>


### PR DESCRIPTION
## Summary

Closes #8

- Added `cursor-default` to the nav sidebar (Panel 1) container to prevent the col-resize cursor from appearing when hovering over its right border edge
- The nav sidebar width is fixed (toggled via PanelLeft button), so the resize affordance was misleading
- ResizeHandle between Panel 2 and Panel 3 remains unaffected

## Changes

- `src/components/layout/AppShell.tsx` — added `cursor-default` class to Panel 1 desktop container

## How to verify

1. Run `pnpm dev` and open the app
2. Hover over the right edge of the nav sidebar (Panel 1)
3. Confirm cursor does NOT change to col-resize
4. Confirm border does NOT darken on hover
5. Verify Panel 2/Panel 3 resize still works

## Testing

- [x] Build succeeds
- [ ] Manual verification done

---
Generated with [Claude Code](https://claude.com/claude-code)