### PR TITLE
feat: replace tab bar chips with global top bar and + button

### DIFF
--- a/src/components/content/ContentPanel.tsx
+++ b/src/components/content/ContentPanel.tsx
@@ -8,10 +8,8 @@ import ContentFooter from '@/components/content/ContentFooter'
 
 export default function ContentPanel({ children }: { children: React.ReactNode }) {
   const {
-    openTabs,
     activeSlug,
-    navigateTo,
-    closeTab,
+    openPane,
     panel3Visible,
     setPanel3Visible,
     viewportWidth,
@@ -21,10 +19,7 @@ export default function ContentPanel({ children }: { children: React.ReactNode }
   return (
     <div className="flex h-full flex-col">
       <TabBar
-        openTabs={openTabs}
-        activeSlug={activeSlug}
-        onTabClick={navigateTo}
-        onTabClose={closeTab}
+        onNewPane={() => openPane(null)}
         onTogglePanel3={() => setPanel3Visible(!panel3Visible)}
         onHamburger={
           viewportWidth < BREAKPOINTS.MOBILE

--- a/src/components/content/ContentPanelRight.tsx
+++ b/src/components/content/ContentPanelRight.tsx
@@ -17,7 +17,7 @@ type ContentPanelRightProps = {
 export default function ContentPanelRight({ externalSlug }: ContentPanelRightProps) {
   const { treeData } = useAppShell()
   const [compareSlug, setCompareSlug] = useState(DEFAULT_FIRM_SLUG)
-  const { openTabs, activeSlug, closeTab } = useTabManager(
+  const { activeSlug } = useTabManager(
     treeData,
     '/' + compareSlug,
     'compareTab',
@@ -66,13 +66,7 @@ export default function ContentPanelRight({ externalSlug }: ContentPanelRightPro
 
   return (
     <div className="flex h-full flex-col">
-      <TabBar
-        openTabs={openTabs}
-        activeSlug={activeSlug}
-        onTabClick={(slug) => setCompareSlug(slug)}
-        onTabClose={closeTab}
-        onTogglePanel3={undefined}
-      />
+      <TabBar />
       <BreadcrumbBar activeSlug={activeSlug} />
       <div className="flex-1 overflow-y-auto p-6">
         {loading ? (

--- a/src/components/content/TabBar.tsx
+++ b/src/components/content/TabBar.tsx
@@ -1,29 +1,21 @@
 'use client'
 
-import { Menu, X, PanelRight, Search } from 'lucide-react'
-import { cn } from '@/lib/utils'
+import { Menu, Plus, PanelRight, Search } from 'lucide-react'
 import {
   Tooltip,
   TooltipContent,
   TooltipTrigger,
 } from '@/components/ui/tooltip'
 import { useSearch } from '@/contexts/SearchContext'
-import type { TabEntry } from '@/types/content'
 
 type TabBarProps = {
-  openTabs: TabEntry[]
-  activeSlug: string
-  onTabClick: (slug: string) => void
-  onTabClose: (slug: string) => void
+  onNewPane?: () => void
   onTogglePanel3?: () => void
   onHamburger?: () => void
 }
 
 export default function TabBar({
-  openTabs,
-  activeSlug,
-  onTabClick,
-  onTabClose,
+  onNewPane,
   onTogglePanel3,
   onHamburger,
 }: TabBarProps) {
@@ -43,49 +35,23 @@ export default function TabBar({
         </button>
       )}
 
-      {/* Tabs scroll container */}
-      <div className="tab-scroll flex flex-1 overflow-x-auto">
-        {openTabs.map((tab) => {
-          const isActive = tab.slug === activeSlug
-          return (
-            <div
-              key={tab.slug}
-              role="tab"
-              tabIndex={0}
-              aria-selected={isActive}
-              onClick={() => onTabClick(tab.slug)}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter' || e.key === ' ') {
-                  e.preventDefault()
-                  onTabClick(tab.slug)
-                }
-              }}
-              className={cn(
-                'group flex h-9 max-w-[200px] min-w-[120px] shrink-0 items-center gap-1.5 px-3',
-                'relative cursor-pointer border-r border-[var(--border)]',
-                isActive
-                  ? 'border-b-2 border-b-[var(--accent)] bg-[var(--background)]'
-                  : 'bg-[var(--sidebar-bg)] hover:bg-[var(--muted)]',
-              )}
-            >
-              <span className="flex-1 truncate text-[13px] text-[var(--foreground)]">
-                {tab.title}
-              </span>
-              <button
-                type="button"
-                aria-label="Close tab"
-                className="rounded-sm p-0.5 opacity-0 transition-opacity group-hover:opacity-100 hover:bg-[var(--muted)]"
-                onClick={(e) => {
-                  e.stopPropagation()
-                  onTabClose(tab.slug)
-                }}
-              >
-                <X size={11} />
-              </button>
-            </div>
-          )
-        })}
-      </div>
+      {/* Spacer — fills the centre so action buttons stay right-aligned */}
+      <div className="flex-1" />
+
+      {/* New pane button */}
+      {onNewPane && (
+        <Tooltip>
+          <TooltipTrigger
+            type="button"
+            onClick={onNewPane}
+            aria-label="New pane"
+            className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md hover:bg-[var(--muted)]"
+          >
+            <Plus size={16} />
+          </TooltipTrigger>
+          <TooltipContent>New pane</TooltipContent>
+        </Tooltip>
+      )}
 
       {/* Search button — reads from SearchContext */}
       <button


### PR DESCRIPTION
## Summary

- Removes per-file tab chip rendering from `TabBar.tsx` — no horizontal tab row is shown in the top bar
- Adds a "+" (`Plus`) button that calls `openPane(null)` to create a new empty pane, wired through a new `onNewPane` prop
- Hamburger (mobile), search (Cmd+K), and Panel 3 toggle remain fully functional
- Bar height unchanged at `h-9` (~36px)

## Changes

- `src/components/content/TabBar.tsx` — strips `openTabs`, `activeSlug`, `onTabClick`, `onTabClose` props; adds `onNewPane` prop; replaces tab scroll container with a flex spacer; adds `Plus` icon button with tooltip
- `src/components/content/ContentPanel.tsx` — removes tab-related context reads (`openTabs`, `navigateTo`, `closeTab`); passes `() => openPane(null)` as `onNewPane`
- `src/components/content/ContentPanelRight.tsx` — removes unused tab props from `<TabBar>` usage; cleans up unused `openTabs`/`closeTab` destructuring

## Test plan

- [ ] Top bar renders with no tab chips
- [ ] "+" button is visible; clicking it creates a new pane entry (verify via context/localStorage)
- [ ] Search button opens the search palette
- [ ] Panel 3 toggle button shows/hides the right panel
- [ ] Hamburger icon appears only on mobile viewports and opens the nav overlay
- [ ] `pnpm build` passes with no TypeScript or lint errors

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)