### PR TITLE
feat: add PaneHeader component (close, nav, breadcrumb)

### DIFF
--- a/src/components/content/ContentPanel.tsx
+++ b/src/components/content/ContentPanel.tsx
@@ -3,7 +3,7 @@
 import { BREAKPOINTS } from '@/lib/constants'
 import { useAppShell } from '@/contexts/AppShellContext'
 import TabBar from '@/components/content/TabBar'
-import { BreadcrumbBar } from '@/components/content/BreadcrumbBar'
+import { PaneHeader } from '@/components/content/PaneHeader'
 import ContentFooter from '@/components/content/ContentFooter'
 
 export default function ContentPanel({ children }: { children: React.ReactNode }) {
@@ -32,7 +32,7 @@ export default function ContentPanel({ children }: { children: React.ReactNode }
             : undefined
         }
       />
-      <BreadcrumbBar activeSlug={activeSlug} />
+      <PaneHeader paneId="pane-default" activeSlug={activeSlug} />
       <div className="flex-1 overflow-y-auto">
         {children}
         <ContentFooter />

--- a/src/components/content/ContentPanelRight.tsx
+++ b/src/components/content/ContentPanelRight.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from 'react'
 import TabBar from '@/components/content/TabBar'
-import { BreadcrumbBar } from '@/components/content/BreadcrumbBar'
+import { PaneHeader } from '@/components/content/PaneHeader'
 import MarkdownRenderer from '@/components/content/MarkdownRenderer'
 import { Skeleton } from '@/components/ui/skeleton'
 import { useTabManager } from '@/hooks/useTabManager'
@@ -73,7 +73,7 @@ export default function ContentPanelRight({ externalSlug }: ContentPanelRightPro
         onTabClose={closeTab}
         onTogglePanel3={undefined}
       />
-      <BreadcrumbBar activeSlug={activeSlug} />
+      <PaneHeader paneId="pane-compare" activeSlug={activeSlug} />
       <div className="flex-1 overflow-y-auto p-6">
         {loading ? (
           <>

--- a/src/components/content/PaneHeader.tsx
+++ b/src/components/content/PaneHeader.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useRef, useState } from 'react'
 import { useRouter } from 'next/navigation'
-import { ChevronLeft, ChevronRight } from 'lucide-react'
+import { ChevronLeft, ChevronRight, FileText, X } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import {
   Breadcrumb,
@@ -11,10 +11,7 @@ import {
   BreadcrumbPage,
   BreadcrumbSeparator,
 } from '@/components/ui/breadcrumb'
-
-type BreadcrumbBarProps = {
-  activeSlug: string
-}
+import { useAppShell } from '@/contexts/AppShellContext'
 
 const MAX_HISTORY = 100
 const CATEGORY_SEGMENTS = new Set(['cfd', 'futures'])
@@ -29,8 +26,15 @@ function formatSegment(segment: string): string {
     .join(' ')
 }
 
-export function BreadcrumbBar({ activeSlug }: BreadcrumbBarProps) {
+type PaneHeaderProps = {
+  paneId: string
+  activeSlug: string
+}
+
+export function PaneHeader({ paneId, activeSlug }: PaneHeaderProps) {
   const router = useRouter()
+  const { closePane } = useAppShell()
+
   const backStack = useRef<string[]>([])
   const forwardStack = useRef<string[]>([])
   const prevSlug = useRef<string>('')
@@ -68,6 +72,10 @@ export function BreadcrumbBar({ activeSlug }: BreadcrumbBarProps) {
     router.push('/' + slug)
   }
 
+  function handleClose() {
+    closePane(paneId)
+  }
+
   const withoutPrefix = activeSlug.startsWith('firms/')
     ? activeSlug.slice('firms/'.length)
     : activeSlug
@@ -75,7 +83,19 @@ export function BreadcrumbBar({ activeSlug }: BreadcrumbBarProps) {
   const labels = rawSegments.map(formatSegment)
 
   return (
-    <div className="flex h-9 items-center gap-1 border-b border-[var(--border)] px-6">
+    <div className="flex h-9 items-center gap-1 border-b border-[var(--border)] px-2">
+      {/* Close button */}
+      <button
+        type="button"
+        onClick={handleClose}
+        aria-label="Close pane"
+        className="flex items-center justify-center rounded p-0.5 cursor-pointer text-[var(--muted-foreground)] hover:text-[var(--foreground)] transition-colors"
+      >
+        <X size={14} />
+      </button>
+
+      <span className="text-[var(--border)] select-none px-0.5">|</span>
+
       {/* Back button */}
       <button
         type="button"
@@ -108,8 +128,14 @@ export function BreadcrumbBar({ activeSlug }: BreadcrumbBarProps) {
         <ChevronRight size={16} />
       </button>
 
-      <span className="mx-2 text-[var(--muted-foreground)]">/</span>
+      {/* File icon */}
+      <FileText
+        size={14}
+        className="shrink-0 text-[var(--muted-foreground)]"
+        aria-hidden="true"
+      />
 
+      {/* Breadcrumb path */}
       <Breadcrumb>
         <BreadcrumbList className="flex-nowrap gap-1">
           {labels.map((label, index) => {


### PR DESCRIPTION
## Summary

- Adds `src/components/content/PaneHeader.tsx` — per-pane header with X close button, back/forward nav arrows, file icon, and breadcrumb path
- Migrates all breadcrumb and history-stack logic from the now-deleted `BreadcrumbBar.tsx` into `PaneHeader`
- Wires `PaneHeader` into `ContentPanel` (main pane, `paneId="pane-default"`) and `ContentPanelRight` (compare pane, `paneId="pane-compare"`)
- Deletes `BreadcrumbBar.tsx` — no remaining imports anywhere in the codebase

## Design

- Back/forward arrows visually disabled (`opacity-30`, `cursor-not-allowed`) when no history exists in that pane's local stack
- Breadcrumb strips the `firms/` prefix and formats each segment (e.g. `CFD / Funded Next / Challenges / 50K`)
- X close button calls `closePane(paneId)` from `AppShellContext` — last pane is protected by the context (never closes)
- File icon (`FileText` from lucide-react) sits between the nav arrows and breadcrumb, matching Obsidian's per-tab header aesthetic
- All colors use design-token CSS variables (`--border`, `--foreground`, `--muted-foreground`)

## Test plan

- [ ] Navigate between pages and verify back/forward arrows enable/disable correctly per-pane
- [ ] Verify breadcrumb shows correct folder segments for a nested slug (e.g. `CFD / Funded Next / Challenges / 50K`)
- [ ] Click a non-last, non-category breadcrumb segment and confirm navigation
- [ ] Verify X button does not close the last remaining pane
- [ ] Confirm no TypeScript errors: `pnpm build` passes
- [ ] Confirm no lint errors: `pnpm lint` passes

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)