### PR TITLE
feat: add sources panel in right sidebar (Panel 3)

### DIFF
--- a/src/app/firms/[...slug]/page.tsx
+++ b/src/app/firms/[...slug]/page.tsx
@@ -3,7 +3,7 @@ import { getPageContent } from '@/lib/content/getPageContent'
 import VerifiedBadge from '@/components/content/VerifiedBadge'
 import MarkdownRenderer from '@/components/content/MarkdownRenderer'
 import SourceFootnotes from '@/components/content/SourceFootnotes'
-import SourcesFooter from '@/components/content/SourcesFooter'
+import SourcesFooterConnected from '@/components/content/SourcesFooterConnected'
 
 export const dynamic = 'force-static'
 
@@ -58,7 +58,7 @@ export default async function FirmPage({
       />
       <MarkdownRenderer htmlContent={htmlContent} />
       <SourceFootnotes sources={frontmatter.sources} />
-      <SourcesFooter sources={frontmatter.sources} />
+      <SourcesFooterConnected sources={frontmatter.sources} />
     </article>
   )
 }

--- a/src/components/content/SourcesFooterConnected.tsx
+++ b/src/components/content/SourcesFooterConnected.tsx
@@ -1,0 +1,24 @@
+'use client'
+
+import { useAppShell } from '@/contexts/AppShellContext'
+import SourcesFooter from '@/components/content/SourcesFooter'
+import type { SourceEntry } from '@/types/content'
+
+type SourcesFooterConnectedProps = {
+  sources: SourceEntry[]
+}
+
+/**
+ * Client wrapper that connects SourcesFooter's onOpen callback to the
+ * AppShell context, opening Panel 3 in sources mode.
+ */
+export default function SourcesFooterConnected({ sources }: SourcesFooterConnectedProps) {
+  const { openSourcesPanel } = useAppShell()
+
+  return (
+    <SourcesFooter
+      sources={sources}
+      onOpen={() => openSourcesPanel(sources)}
+    />
+  )
+}

--- a/src/components/content/SourcesPanel.tsx
+++ b/src/components/content/SourcesPanel.tsx
@@ -1,0 +1,114 @@
+'use client'
+
+import type { SourceEntry } from '@/types/content'
+
+type SourcesPanelProps = {
+  sources: SourceEntry[]
+}
+
+function extractDomain(url: string): string {
+  try {
+    return new URL(url).hostname.replace(/^www\./, '')
+  } catch {
+    return url
+  }
+}
+
+function SourceRow({ source }: { source: SourceEntry }) {
+  const domain = extractDomain(source.url)
+
+  return (
+    <a
+      href={source.url}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="group flex flex-col gap-1 rounded-md border border-[var(--border)] bg-[var(--muted)] px-3 py-2.5 transition-colors hover:border-[var(--accent)] hover:bg-[var(--interactive-hover)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
+    >
+      <div className="flex items-center gap-2">
+        {/* Favicon — external Google service, next/image not applicable */}
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img
+          src={`https://www.google.com/s2/favicons?domain=${domain}&sz=16`}
+          alt=""
+          aria-hidden="true"
+          width={14}
+          height={14}
+          className="size-3.5 shrink-0 rounded-sm object-contain"
+          onError={(e) => {
+            e.currentTarget.style.display = 'none'
+          }}
+        />
+
+        {/* Official badge */}
+        {source.isOfficial && (
+          <span className="inline-flex items-center rounded-sm bg-[var(--accent)] px-1 py-px text-[10px] font-semibold leading-none text-white">
+            Official
+          </span>
+        )}
+
+        {/* Label */}
+        <span className="flex-1 truncate text-[13px] font-medium text-[var(--foreground)] group-hover:text-[var(--accent)]">
+          {source.label}
+        </span>
+
+        {/* External link icon */}
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 16 16"
+          fill="currentColor"
+          className="size-3 shrink-0 text-[var(--muted-foreground)] opacity-0 transition-opacity group-hover:opacity-100"
+          aria-hidden="true"
+        >
+          <path d="M6.22 8.72a.75.75 0 0 0 1.06 1.06l5.22-5.22v1.69a.75.75 0 0 0 1.5 0v-3.5a.75.75 0 0 0-.75-.75h-3.5a.75.75 0 0 0 0 1.5h1.69L6.22 8.72Z" />
+          <path d="M3.5 6.75c0-.69.56-1.25 1.25-1.25H7A.75.75 0 0 0 7 4H4.75A2.75 2.75 0 0 0 2 6.75v4.5A2.75 2.75 0 0 0 4.75 14h4.5A2.75 2.75 0 0 0 12 11.25V9a.75.75 0 0 0-1.5 0v2.25c0 .69-.56 1.25-1.25 1.25h-4.5c-.69 0-1.25-.56-1.25-1.25v-4.5Z" />
+        </svg>
+      </div>
+
+      {/* Domain */}
+      <span className="text-[11px] text-[var(--muted-foreground)]">{domain}</span>
+
+      {/* Description */}
+      {source.description && (
+        <p className="text-[12px] leading-snug text-[var(--muted-foreground)]">
+          {source.description}
+        </p>
+      )}
+    </a>
+  )
+}
+
+export default function SourcesPanel({ sources }: SourcesPanelProps) {
+  // Deduplicate by URL
+  const seen = new Set<string>()
+  const deduped: SourceEntry[] = []
+  for (const s of sources) {
+    if (!seen.has(s.url)) {
+      seen.add(s.url)
+      deduped.push(s)
+    }
+  }
+
+  // Official sources first, then the rest
+  const sorted = [
+    ...deduped.filter((s) => s.isOfficial),
+    ...deduped.filter((s) => !s.isOfficial),
+  ]
+
+  if (sorted.length === 0) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <p className="text-[13px] text-[var(--muted-foreground)]">No sources available.</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex h-full flex-col overflow-y-auto px-3 py-3">
+      <div className="flex flex-col gap-2">
+        {sorted.map((source, i) => (
+          <SourceRow key={`${source.url}-${i}`} source={source} />
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/components/graph/GraphPanel.tsx
+++ b/src/components/graph/GraphPanel.tsx
@@ -12,6 +12,7 @@ import { useAppShell } from '@/contexts/AppShellContext'
 import CompareAuthGate from '@/components/auth/CompareAuthGate'
 import GraphViewLoader from '@/components/graph/GraphViewLoader'
 import ContentPanelRight from '@/components/content/ContentPanelRight'
+import SourcesPanel from '@/components/content/SourcesPanel'
 
 export default function GraphPanel() {
   const {
@@ -22,12 +23,13 @@ export default function GraphPanel() {
     activeSlug,
     navigateTo,
     compareSlug,
+    sourcesEntries,
   } = useAppShell()
 
   const [pendingCompare, setPendingCompare] = useState(false)
 
   const handleModeToggleClick = () => {
-    if (panel3Mode === 'compare') {
+    if (panel3Mode === 'compare' || panel3Mode === 'sources') {
       setPanel3Mode('graph')
     } else {
       if (user) {
@@ -51,7 +53,7 @@ export default function GraphPanel() {
     <div className="flex h-full flex-col">
       <div className="flex h-10 shrink-0 items-center justify-between border-b border-[var(--border)] px-3">
         <span className="text-[12px] font-medium text-[var(--muted-foreground)]">
-          {panel3Mode === 'graph' ? 'Graph' : 'Compare'}
+          {panel3Mode === 'graph' ? 'Graph' : panel3Mode === 'sources' ? 'Sources' : 'Compare'}
         </span>
         <Tooltip>
           <TooltipTrigger
@@ -70,7 +72,9 @@ export default function GraphPanel() {
       </div>
 
       <div className="flex-1 overflow-hidden">
-        {pendingCompare || (panel3Mode === 'compare' && !user) ? (
+        {panel3Mode === 'sources' ? (
+          <SourcesPanel sources={sourcesEntries} />
+        ) : pendingCompare || (panel3Mode === 'compare' && !user) ? (
           <CompareAuthGate
             onDismiss={() => {
               setPendingCompare(false)

--- a/src/contexts/AppShellContext.tsx
+++ b/src/contexts/AppShellContext.tsx
@@ -3,7 +3,7 @@
 import { createContext, useContext, useState, useCallback, useMemo } from 'react'
 import { usePathname, useRouter } from 'next/navigation'
 import type { User } from '@supabase/supabase-js'
-import type { TreeNode, TabEntry, PaneEntry } from '@/types/content'
+import type { TreeNode, TabEntry, PaneEntry, SourceEntry } from '@/types/content'
 import { useLocalStorage } from '@/hooks/useLocalStorage'
 import { useViewport } from '@/hooks/useViewport'
 import { useSupabaseUser } from '@/hooks/useSupabaseUser'
@@ -30,12 +30,14 @@ type AppShellContextValue = {
   setActivePane: (id: string) => void
 
   // Panel 3
-  panel3Mode: 'graph' | 'compare'
-  setPanel3Mode: (mode: 'graph' | 'compare') => void
+  panel3Mode: 'graph' | 'compare' | 'sources'
+  setPanel3Mode: (mode: 'graph' | 'compare' | 'sources') => void
   panel3Visible: boolean
   setPanel3Visible: (visible: boolean) => void
   compareSlug: string | null
   openInPanel3: (slug: string) => void
+  sourcesEntries: SourceEntry[]
+  openSourcesPanel: (sources: SourceEntry[]) => void
 
   // Auth
   user: User | null
@@ -102,10 +104,11 @@ export function AppShellProvider({ treeData, children }: AppShellProviderProps) 
     setActivePaneId(id)
   }, [setActivePaneId])
 
-  const [panel3Mode, setPanel3Mode] = useLocalStorage<'graph' | 'compare'>('panel3Mode', 'graph')
+  const [panel3Mode, setPanel3Mode] = useLocalStorage<'graph' | 'compare' | 'sources'>('panel3Mode', 'graph')
   const [panel3Visible, setPanel3Visible] = useState(false)
   const [panel1OverlayOpen, setPanel1OverlayOpen] = useState(false)
   const [compareSlug, setCompareSlug] = useState<string | null>(null)
+  const [sourcesEntries, setSourcesEntries] = useState<SourceEntry[]>([])
 
   const navigateTo = useCallback((slug: string) => {
     router.push('/' + slug)
@@ -114,6 +117,12 @@ export function AppShellProvider({ treeData, children }: AppShellProviderProps) 
   const openInPanel3 = useCallback((slug: string) => {
     setCompareSlug(slug)
     setPanel3Mode('compare')
+    setPanel3Visible(true)
+  }, [setPanel3Mode])
+
+  const openSourcesPanel = useCallback((sources: SourceEntry[]) => {
+    setSourcesEntries(sources)
+    setPanel3Mode('sources')
     setPanel3Visible(true)
   }, [setPanel3Mode])
 
@@ -135,6 +144,8 @@ export function AppShellProvider({ treeData, children }: AppShellProviderProps) 
     setPanel3Visible,
     compareSlug,
     openInPanel3,
+    sourcesEntries,
+    openSourcesPanel,
     user,
     authLoading,
     viewportWidth,


### PR DESCRIPTION
## Summary

- Adds `sources` mode to Panel 3 — clicking the sources footer now opens a dedicated sources panel in the right sidebar
- `SourcesPanel` deduplicates entries by URL, sorts official sources first, and renders each source with favicon, label, domain, optional description, and external link
- `SourcesFooterConnected` is a thin client wrapper that wires `SourcesFooter`'s `onOpen` callback to `AppShellContext.openSourcesPanel`
- Panel 3 header label updates to "Sources" when in sources mode; the graph/compare toggle returns to graph view

## Changes

| File | Change |
|------|--------|
| `AppShellContext.tsx` | Added `sources` to `panel3Mode` union; added `sourcesEntries` state and `openSourcesPanel` action |
| `SourcesPanel.tsx` | New component — dedup, sort, render source list |
| `SourcesFooterConnected.tsx` | New client wrapper connecting footer to context |
| `GraphPanel.tsx` | Render `SourcesPanel` when `panel3Mode === 'sources'` |
| `firms/[...slug]/page.tsx` | Swap `SourcesFooter` for `SourcesFooterConnected` |

## Test plan

- [ ] Navigate to any firm page (e.g. `/firms/cfd/funded-next/rules`)
- [ ] Click the sources footer bar at the bottom of the content
- [ ] Verify Panel 3 opens with the "Sources" header label
- [ ] Verify each source shows: favicon, label, domain, description (if present)
- [ ] Verify official sources (isOfficial: true) have the purple "Official" badge and appear first
- [ ] Verify duplicate source URLs across pages appear only once in the panel
- [ ] Verify clicking a source row opens the URL in a new tab
- [ ] Verify Panel 3 close button (toggle) returns to graph view
- [ ] `pnpm build` passes with no errors

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)