### PR TITLE
feat: add empty pane state for new tab landing

### DIFF
--- a/src/components/content/EmptyPaneState.tsx
+++ b/src/components/content/EmptyPaneState.tsx
@@ -1,0 +1,50 @@
+'use client'
+
+import { useAppShell } from '@/contexts/AppShellContext'
+import { useSearch } from '@/contexts/SearchContext'
+
+type EmptyPaneStateProps = {
+  paneId: string
+}
+
+export default function EmptyPaneState({ paneId }: EmptyPaneStateProps) {
+  const { closePane } = useAppShell()
+  const { open: openSearch } = useSearch()
+
+  return (
+    <div className="flex h-full items-center justify-center">
+      <div className="flex flex-col items-center gap-1">
+        <button
+          type="button"
+          disabled
+          aria-disabled="true"
+          className="flex w-full items-center justify-between gap-6 rounded px-3 py-1.5 text-sm text-[var(--muted-foreground)] opacity-40 cursor-not-allowed"
+        >
+          <span>Create new note</span>
+          <kbd className="rounded bg-[var(--muted)] px-1.5 py-0.5 text-xs font-mono text-[var(--muted-foreground)]">
+            Cmd+N
+          </kbd>
+        </button>
+
+        <button
+          type="button"
+          onClick={openSearch}
+          className="flex w-full items-center justify-between gap-6 rounded px-3 py-1.5 text-sm text-[var(--muted-foreground)] transition-colors duration-150 hover:bg-[var(--muted)] hover:text-[var(--foreground)]"
+        >
+          <span>Go to file</span>
+          <kbd className="rounded bg-[var(--muted)] px-1.5 py-0.5 text-xs font-mono text-[var(--muted-foreground)]">
+            Cmd+O
+          </kbd>
+        </button>
+
+        <button
+          type="button"
+          onClick={() => closePane(paneId)}
+          className="flex w-full items-center justify-between gap-6 rounded px-3 py-1.5 text-sm text-[var(--muted-foreground)] transition-colors duration-150 hover:bg-[var(--muted)] hover:text-[var(--foreground)]"
+        >
+          <span>Close</span>
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/components/content/SplitPaneLayout.tsx
+++ b/src/components/content/SplitPaneLayout.tsx
@@ -4,6 +4,7 @@ import { useCallback } from 'react'
 import { useAppShell } from '@/contexts/AppShellContext'
 import { PaneHeader } from '@/components/content/PaneHeader'
 import PaneTitleStrip from '@/components/content/PaneTitleStrip'
+import EmptyPaneState from '@/components/content/EmptyPaneState'
 import { BREAKPOINTS } from '@/lib/constants'
 import type { PaneEntry } from '@/types/content'
 
@@ -53,7 +54,11 @@ export default function SplitPaneLayout({ children }: SplitPaneLayoutProps) {
       <div className="flex h-full min-w-0 flex-1 flex-col">
         <PaneHeader paneId={activePane.id} activeSlug={activePane.slug ?? ''} />
         <div className="flex-1 overflow-y-auto">
-          {children}
+          {activePane.slug === null ? (
+            <EmptyPaneState paneId={activePane.id} />
+          ) : (
+            children
+          )}
         </div>
       </div>
     )
@@ -69,7 +74,7 @@ export default function SplitPaneLayout({ children }: SplitPaneLayoutProps) {
           return (
             <PaneTitleStrip
               key={pane.id}
-              title={pane.title}
+              title={pane.slug === null ? 'New tab' : pane.title}
               isActive={pane.id === activePaneId}
               onClick={() => handleCollapsedClick(pane)}
             />
@@ -87,14 +92,16 @@ export default function SplitPaneLayout({ children }: SplitPaneLayoutProps) {
           >
             <PaneHeader paneId={pane.id} activeSlug={pane.slug ?? ''} />
             <div className="flex-1 overflow-y-auto">
-              {isRightmost ? (
+              {pane.slug === null ? (
+                <EmptyPaneState paneId={pane.id} />
+              ) : isRightmost ? (
                 children
               ) : (
-                // Second expanded pane — shows empty/placeholder state until
-                // the pane data model wires up per-pane content loading.
+                // Second expanded pane — shows placeholder until per-pane
+                // content loading is wired up.
                 <div className="flex h-full items-center justify-center">
                   <p className="text-sm text-[var(--muted-foreground)]">
-                    {pane.slug ? pane.title : 'Empty pane'}
+                    {pane.title}
                   </p>
                 </div>
               )}


### PR DESCRIPTION
## Summary

- Adds `EmptyPaneState` component rendered when a pane has `slug === null`
- Three centered action buttons: disabled "Create new note (Cmd+N)", functional "Go to file (Cmd+O)" that opens the existing `SearchModal` via `SearchContext`, and "Close" that calls `closePane(id)`
- Collapsed title strips now show "New tab" for panes with null slug
- Styling uses Obsidian design tokens (`--muted-foreground`, `--muted`, `--foreground`) at `text-sm` with hover state transitions

## Test plan

- [ ] Click "+" to open a new pane — empty state renders with all three buttons centered
- [ ] Click "Go to file" — search modal opens
- [ ] Click "Close" — pane is removed (disabled when only one pane remains)
- [ ] Collapse a null-slug pane to a title strip — strip reads "New tab"
- [ ] On mobile, navigate to an empty pane — empty state renders full-width
- [ ] `pnpm build` passes with no TypeScript or compile errors

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)