### PR TITLE
[bug] pane-aware file-tree navigation

### DIFF
--- a/src/components/content/SplitPaneLayout.tsx
+++ b/src/components/content/SplitPaneLayout.tsx
@@ -28,7 +28,7 @@ type SplitPaneLayoutProps = {
  * collapsed strips are hidden entirely.
  */
 export default function SplitPaneLayout({ children }: SplitPaneLayoutProps) {
-  const { panes, activePaneId, bringPaneForward, viewportWidth } = useAppShell()
+  const { panes, activePaneId, bringPaneForward, setActivePane, viewportWidth } = useAppShell()
 
   // Determine which panes are collapsed.
   // The 2 rightmost panes are always expanded; all others are collapsed.
@@ -87,6 +87,7 @@ export default function SplitPaneLayout({ children }: SplitPaneLayoutProps) {
           <div
             key={pane.id}
             className="flex min-w-0 flex-1 flex-col border-r border-[var(--border)] last:border-r-0"
+            onClick={() => setActivePane(pane.id)}
           >
             <PaneHeader paneId={pane.id} activeSlug={pane.slug ?? ''} />
             <div className="flex-1 overflow-y-auto">

--- a/src/components/nav/NavFileTree.tsx
+++ b/src/components/nav/NavFileTree.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { useEffect, useState, useRef, useCallback, useMemo } from 'react'
-import { useRouter } from 'next/navigation'
 import {
   BookOpen,
   ChevronRight,
@@ -11,6 +10,7 @@ import {
   Trophy,
 } from 'lucide-react'
 import { cn } from '@/lib/utils'
+import { useAppShell } from '@/contexts/AppShellContext'
 import type { TreeNode } from '@/types/content'
 
 type NavFileTreeProps = {
@@ -228,7 +228,7 @@ function TreeNodeList({
 }
 
 export default function NavFileTree({ treeData, activeSlug }: NavFileTreeProps) {
-  const router = useRouter()
+  const { activePaneId, navigatePane } = useAppShell()
   const nodeRefs = useRef<Map<string, HTMLElement>>(new Map())
 
   const [expanded, setExpanded] = useState<Record<string, boolean>>(() => ({}))
@@ -277,9 +277,9 @@ export default function NavFileTree({ treeData, activeSlug }: NavFileTreeProps) 
 
   const handleFileClick = useCallback(
     (id: string) => {
-      router.push('/' + id)
+      navigatePane(activePaneId, id)
     },
-    [router],
+    [navigatePane, activePaneId],
   )
 
   // Memoized visible list — recomputed only when treeData or expanded changes, not on every keypress


### PR DESCRIPTION
## Summary
- `NavFileTree` now routes clicks through `navigatePane()` instead of `router.push()`, so files open in the active pane rather than replacing the whole URL.
- Clicking a pane's body marks it as active, matching the pane-aware UX model.

## Why
`router.push()` defeats the split-pane system introduced in #30 — the global URL change unloads the pane layout. This fix keeps the vault navigation correct on the `/vault` route that v1's spec requires to keep rendering.

## Test plan
- [x] \`pnpm tsc --noEmit\` clean
- [ ] Manual: open two panes, click a file in the left pane's tree → opens in active (right) pane
- [ ] Manual: click in the left pane body → it becomes active, subsequent tree clicks land there

🤖 Generated with [Claude Code](https://claude.com/claude-code)